### PR TITLE
4.1

### DIFF
--- a/src/tests/test04.vtc
+++ b/src/tests/test04.vtc
@@ -1,3 +1,4 @@
+varnishtest "Test for something"
 server s1 {
         rxreq
         txresp -hdr "OK: yes"

--- a/src/vmod_core.c
+++ b/src/vmod_core.c
@@ -13,11 +13,10 @@ HSH_AddBytes(const struct req *req, const struct vrt_ctx *ctx,
 }
 
 
-static int __match_proto__(req_body_iter_f)
-IterCopyReqBody(struct req *req, void *priv, void *ptr, size_t l)
+static int __match_proto__(objiterate_f)
+IterCopyReqBody(void *priv, int flush, const void *ptr, ssize_t l)
 {
 	struct vsb *iter_vsb = priv;
-	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 
 	return (VSB_bcat(iter_vsb, ptr, l));
 }


### PR DESCRIPTION
Varnish 5.0 seems to have unified the iteration proto, first commit fixes that. Second commit adds a comment line so that varnishtest will run the test.

I’d guess the symbol change breaks compilation with 4.x, so maybe another branch for 5.0 would be good idea?
