### PR TITLE
Added .req_body() to let body available in VCL 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,29 @@ Example
 		| if (bodyaccess.rematch_req_body("FOO") == 1) {
 		|    std.log("is true");
 		| }
+req_body
+-------------
+
+Prototype
+        ::
+
+                req_body()
+Return value
+        STRING
+Description
+        Return available request body to VCL.
+	Note that this function can only be used in vcl_recv and
+	the request body must already be in std buffer.
+        Its intent is for a small body, workspace's storage is used.
+Example
+        ::
+
+                | sub vcl_recv {
+		|     std.cache_req_body(256B);
+                |
+		|     set req.http.body = regsub(bodyaccess.req_body(), "foo", "bar");
+		| }
+
 
 Find more example in example.vcl.
 

--- a/src/tests/test05.vtc
+++ b/src/tests/test05.vtc
@@ -1,0 +1,27 @@
+varnishtest "test regex match on req body"
+
+server s1 {
+	rxreq
+        expect req.body == "BANANE"
+        expect req.http.foobar == "BANANAS"
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import bodyaccess from "${vmod_topbuild}/src/.libs/libvmod_bodyaccess.so";
+	import std;
+	
+	sub vcl_recv {
+		std.cache_req_body(100B);
+		set req.http.req_body = bodyaccess.req_body();
+		set req.http.foobar = regsub(req.http.req_body, "NE", "NAS");
+                unset req.http.req_body;
+	}
+}
+
+varnish v1 -start
+
+client c1 {
+	txreq -req "POST" -body {BANANE}
+	rxresp
+} -run

--- a/src/vmod_bodyaccess.vcc
+++ b/src/vmod_bodyaccess.vcc
@@ -5,3 +5,5 @@ $Function INT rematch_req_body(PRIV_CALL, STRING re)
 $Function VOID hash_req_body()
 
 $Function INT len_req_body()
+
+$Function STRING req_body()


### PR DESCRIPTION
Alongs with the same needs as https://github.com/aondio/libvmod-bodyaccess/issues/12, accessing a POST request's body in VCL and set custom HTTP Header, Variables, Processing or Checks is useful. 

This .req_body() implementation is limited by the size of the workspace.
However, for most of the cases, it's perfectly valid and sufficient.