### PR TITLE
replaced buffer_req_body() in examples

### DIFF
--- a/example.vcl
+++ b/example.vcl
@@ -1,22 +1,11 @@
 # VCL examples.
 # Tip: read up the tests for more complex use-cases
 
-# buffer_req_body(BYTES size)
-# It can be called only from vcl_recv.
-sub vcl_recv {
-	if(bodyaccess.buffer_req_body(110B)) {
-		...
-	}
-}
-
-/------------------------------------------------------------------------------/
-
 # len_req_body()
 # It can be called only from vcl_recv.
 sub vcl_recv {
-	if(bodyaccess.buffer_req_body(110B)) {
-		set req.http.x-len = bodyaccess.len_req_body();
-	}
+	std.cache_req_body(110B);
+	set req.http.x-len = bodyaccess.len_req_body();
 }
 
 sub vcl_deliver {
@@ -28,9 +17,8 @@ sub vcl_deliver {
 # hash_req_body()
 # It can be called only form vcl_hash.
 sub vcl_recv {
-	if(bodyaccess.buffer_req_body(110B)) {
-		return (hash);
-	}
+	std.cache_req_body(110B);
+	return (hash);
 }
 
 sub vcl_hash {
@@ -43,9 +31,9 @@ sub vcl_hash {
 # rematch_req_body(STRING re)
 # It can be called only form vcl_recv.
 sub vcl_recv {
-	if (bodyaccess.buffer_req_body(10KB)) {
-		set req.http.x-re = bodyaccess.rematch_req_body("Regex");
-	}
+	std.cache_req_body(10KB);
+	set req.http.x-re = bodyaccess.rematch_req_body("Regex");
+
 }
 
 sub vcl_deliver {
@@ -73,10 +61,9 @@ sub vcl_backend_fetch {
 sub vcl_recv {
         if (req.method == "POST") {
                 set req.http.x-method = req.method;
-                if (bodyaccess.buffer_req_body(110KB)) {
-                        set req.http.x-len = bodyaccess.len_req_body();
-                        set req.http.x-re = bodyaccess.rematch_req_body("Regex"$
-                }
+		std.cache_req_body(110KB);
+                set req.http.x-len = bodyaccess.len_req_body();
+                set req.http.x-re = bodyaccess.rematch_req_body("Regex"$
         }
         return(hash);
 


### PR DESCRIPTION
The example.vcl had the old buffer_req_body function, it has been replaced by std.cache_req_body