### PR TITLE
Log the request body to the VSL

### DIFF
--- a/src/tests/test04.vtc
+++ b/src/tests/test04.vtc
@@ -1,3 +1,5 @@
+varnishtest "chunked test"
+
 server s1 {
         rxreq
         txresp -hdr "OK: yes"

--- a/src/tests/test05.vtc
+++ b/src/tests/test05.vtc
@@ -1,0 +1,33 @@
+varnishtest "Test logging POST body"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import bodyaccess from "${vmod_topbuild}/src/.libs/libvmod_bodyaccess.so";
+	import std;
+
+	sub vcl_recv {
+		std.cache_req_body(10KB);
+		bodyaccess.log_req_body("PREFIX:", 3);
+	}
+} -start
+
+logexpect l1 -v v1 {
+	expect * * Debug "^PREFIX:123$"
+	expect 1 = Debug "^PREFIX:456$"
+	expect 1 = Debug "^PREFIX:789$"
+	expect 1 = Debug "^PREFIX:0AB$"
+	expect 1 = Debug "^PREFIX:CDE$"
+	expect 1 = Debug "^PREFIX:F$"
+} -start
+
+client c1 {
+	txreq -req POST -body "1234567890ABCDEF"
+	rxresp
+	expect resp.status == 200
+} -run
+
+logexpect l1 -wait

--- a/src/vmod_bodyaccess.c
+++ b/src/vmod_bodyaccess.c
@@ -19,7 +19,8 @@ vmod_hash_req_body(VRT_CTX)
 	}
 
 	VRB_Blob(ctx, &priv_top);
-	HSH_AddBytes(ctx->req, ctx, priv_top.priv,  priv_top.len);
+	HSH_AddBytes(ctx->req, ctx, VSB_data(priv_top.priv),  priv_top.len);
+	VSB_delete(priv_top.priv);
 }
 
 VCL_INT
@@ -82,8 +83,10 @@ vmod_rematch_req_body(VRT_CTX, struct vmod_priv *priv_call, VCL_STRING re)
 
 	VRB_Blob(ctx, &priv_top);
 
-	i = VRE_exec(priv_call->priv, priv_top.priv, priv_top.len, 0, 0,
+	i = VRE_exec(priv_call->priv, VSB_data(priv_top.priv), priv_top.len, 0, 0,
 	    NULL, 0, NULL);
+
+	VSB_delete(priv_top.priv);
 
 	if (i > 0)
 		return (1);
@@ -94,4 +97,85 @@ vmod_rematch_req_body(VRT_CTX, struct vmod_priv *priv_call, VCL_STRING re)
 	VSLb(ctx->vsl, SLT_VCL_Error, "Regexp matching returned %d", i);
 		return (-1);
 
+}
+
+struct log_req_body {
+	const char *prefix;
+	size_t len;
+};
+
+static int __match_proto__(req_body_iter_f)
+IterLogReqBody(struct req *req, void *priv, void *ptr, size_t len)
+{
+	struct log_req_body *lrb;
+	txt txtbody;
+	static char *str;
+	char *buf;
+	size_t size, prefix_len;
+
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+
+	lrb = priv;
+	str = ptr;
+
+	if (lrb->len > 0)
+		size = lrb->len;
+	else
+		size = len;
+	prefix_len = strlen(lrb->prefix);
+	size += prefix_len;
+
+	buf = malloc(size);
+	AN(buf);
+
+	while (len > 0) {
+		if (len > lrb->len && lrb->len > 0)
+			size = lrb->len;
+		else
+			size = len;
+
+		memcpy(buf, lrb->prefix, prefix_len);
+		memcpy(buf + prefix_len, str, size);
+
+		txtbody.b = buf;
+		txtbody.e = buf + prefix_len + size;
+
+		VSLbt(req->vsl, SLT_Debug, txtbody);
+
+		len -= size;
+		str += size;
+	}
+
+	free(buf);
+
+	return (0);
+}
+
+VCL_VOID
+vmod_log_req_body(VRT_CTX, VCL_STRING prefix, VCL_INT length)
+{
+	struct log_req_body lrb;
+	int ret;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
+
+	if (!prefix)
+		prefix = "";
+
+	lrb.prefix = prefix;
+	lrb.len = length;
+
+	if (ctx->req->req_body_status != REQ_BODY_CACHED) {
+		VSLb(ctx->vsl, SLT_VCL_Error, "Unbuffered req.body");
+		return;
+	}
+
+	ret = VRB_Iterate(ctx->req, IterLogReqBody, &lrb);
+
+	if (ret < 0) {
+		VSLb(ctx->vsl, SLT_VCL_Error,
+		    "Iteration on req.body didn't succeed.");
+		return;
+	}
 }

--- a/src/vmod_bodyaccess.vcc
+++ b/src/vmod_bodyaccess.vcc
@@ -5,3 +5,5 @@ $Function INT rematch_req_body(PRIV_CALL, STRING re)
 $Function VOID hash_req_body()
 
 $Function INT len_req_body()
+
+$Function VOID log_req_body(STRING prefix = "", INT length = 200)

--- a/src/vmod_core.c
+++ b/src/vmod_core.c
@@ -35,13 +35,11 @@ VRB_Blob(VRT_CTX, struct vmod_priv *vmod)
 	l = VRB_Iterate(ctx->req, IterCopyReqBody, (void*)vsb);
 	VSB_finish(vsb);
 	if (l < 0) {
-		VSB_delete(vsb);
 		VSLb(ctx->vsl, SLT_VCL_Error,
 		    "Iteration on req.body didn't succeed.");
 		return;
 	}
 
-	vmod->priv = VSB_data(vsb);
+	vmod->priv = vsb;
 	vmod->len = VSB_len(vsb);
-	VSB_delete(vsb);
 }


### PR DESCRIPTION
We added a new function to log the request body to the VSL so other components could read the body. When logging, it takes an optional prefix and a max line length, so the body could be split up across multiple lines as there is a limit to how large a single line can be.

We had backported the cache request body fix to 4.1, so this PR is based on 4.1.